### PR TITLE
Added switch to cleanup after container exit

### DIFF
--- a/monroe-experiments/usr/bin/monroe-experiments
+++ b/monroe-experiments/usr/bin/monroe-experiments
@@ -46,12 +46,12 @@ mk_disk "metadata";
 
 for IF in "usb0" "usb1" "usb2" "wwan0" "eth0"; do
   if [ -z "$(docker ps --no-trunc|grep $URL_PING|grep $IF)" ]; then
-    docker run -d --net=host -v $BASEDIR/ping:/outdir -v /etc/nodeid:/nodeid:ro $URL_PING $IF;
+    docker run -d --rm=true --net=host -v $BASEDIR/ping:/outdir -v /etc/nodeid:/nodeid:ro $URL_PING $IF;
   fi;
 done
 
 if [ -z "$(docker ps --no-trunc|grep $URL_METADATA)" ]; then
-  docker run -d --net=host -v $BASEDIR/metadata:/outdir -v /etc/nodeid:/nodeid:ro $URL_METADATA;
+  docker run -d --rm=true --net=host -v $BASEDIR/metadata:/outdir -v /etc/nodeid:/nodeid:ro $URL_METADATA;
 fi
 
 echo "Starting rsync of $($RSYNC_LS $BASEDIR | grep json | wc -l) source files to $REPO...";


### PR DESCRIPTION
Since the containers are stateless we do not need to save the filesystem after exit. 

Note: if/when a node suffers from powerloss we still might need to clean up after the containers