### PR TITLE
Admin password must be changed before wifi pw

### DIFF
--- a/mf910-info/usr/bin/mf910-password
+++ b/mf910-info/usr/bin/mf910-password
@@ -12,14 +12,15 @@ NEWADMIN=$3
 echo -n "Login... "
 login $INTERFACE
 
-if [ "$WIFIKEY" != "$NEWWIFI" ]; then
-  echo -n "Updating wifi password... "
-  setcmd 'isTest=false&goformId=SET_WIFI_MULTI_BAND_SETTINGS&isTest=false&m_ssid_enable=0&m_band_enable=0&wifi_multi_band_set=1&security_mode=WPAPSKWPA2PSK&ssid='$IMEI'&wifi_band=b&cipher=1&security_shared_mode=1&passphrase='$( encode $NEWWIFI) -H 'Referer: http://'$MODEM'/index.html'
-fi
 
 if [ "$ADMINKEY" != "$NEWADMIN" ]; then
   echo -n "Updating management password... "
   setcmd 'newPassword='$(encode $NEWADMIN)'&oldPassword='$(encode $ADMINKEY)'&goformId=CHANGE_PASSWORD&isTest=false'
+fi
+
+if [ "$WIFIKEY" != "$NEWWIFI" ]; then
+  echo -n "Updating wifi password... "
+  setcmd 'isTest=false&goformId=SET_WIFI_MULTI_BAND_SETTINGS&isTest=false&m_ssid_enable=0&m_band_enable=0&wifi_multi_band_set=1&security_mode=WPAPSKWPA2PSK&ssid='$IMEI'&wifi_band=b&cipher=1&security_shared_mode=1&passphrase='$( encode $NEWWIFI) -H 'Referer: http://'$MODEM'/index.html'
 fi
 
 echo "WIFIKEY=$NEWWIFI" > /etc/default/mifi.$IMEI


### PR DESCRIPTION
If client is connected via wifi and the wifi password is changed, the connection is dropped and the admin password is not changed.
On the other hand, if the admin password is changed first, the wifi password can easily be changed later.