### PR TITLE
Add -t to preserve modification times

### DIFF
--- a/monroe-experiments/usr/bin/monroe-rsync-results
+++ b/monroe-experiments/usr/bin/monroe-rsync-results
@@ -13,7 +13,7 @@ DEVELOPMENT=$(cat /monroe/development/enabled || echo 0)
 [ $DEVELOPMENT -eq 1 ] && exit 1
 
 SSH="ssh -i $KEY -p 2280 -oStrictHostKeyChecking=no -o ConnectTimeout=30"
-RSYNC_PARMS="-r -z --exclude 'tstat/' --include '*/' --include '*.json' --include '*.xz' --include '*.gz' --exclude '*' --prune-empty-dirs"
+RSYNC_PARMS="-r -t -z --exclude 'tstat/' --include '*/' --include '*.json' --include '*.xz' --include '*.gz' --exclude '*' --prune-empty-dirs"
 RSYNC_ALL="$RSYNC_PARMS -e '$SSH' --remove-source-files --timeout=30 $BASEDIR/ $REPO:$TODIR"
 RSYNC_LS="rsync --ignore-missing-args $RSYNC_PARMS"
 


### PR DESCRIPTION
Files in the repository are timestamped at the time of transfer.
It would be helpful to preserve the local timestamp of the files, by adding -t to the rsync command.