### PR TITLE
Update usb2op.py

### DIFF
--- a/usb2op/usr/bin/usb2op.py
+++ b/usb2op/usr/bin/usb2op.py
@@ -43,10 +43,14 @@ def usb2op(interface, data=None, reverse=False):
                 match = "op%i" % opnr
                 break
                 
-    fd=open("/tmp/interfaces", "w") 
-    for line in config:
-    	fd.write("%s\n" % line) 
-    fd.close()
+    try:
+        fd=open("/tmp/interfaces", "w") 
+        for line in config:
+    	    fd.write("%s\n" % line) 
+        fd.close()
+    except:
+        pass
+    
     return match
 
 if __name__=="__main__":


### PR DESCRIPTION
Running the 'interfaces' command as the monroe user fails with a permission denied error because usb2op tries to write to a root-owned file.

Example:

```
monroe@Monroe000db945e534:~$ interfaces
Traceback (most recent call last):
  File "/usr/bin/interfaces", line 39, in <module>
    print json.dumps(get_interfaces(), indent=2, sort_keys=True)
  File "/usr/bin/interfaces", line 19, in get_interfaces
    op    = usb2op(modem.get('ifname'), data=data)
  File "/usr/bin/usb2op.py", line 46, in usb2op
    fd=open("/tmp/interfaces", "w") 
IOError: [Errno 13] Permission denied: '/tmp/interfaces'
```

The propsed patch adds a try-catch clause to proceed even if the file is not writable.

It's untested, so please verify that it is working.