### PR TITLE
Change the plugin to use existing script for experiment enumeration

### DIFF
--- a/munin-plugins-monroe/etc/munin/plugins/experiments
+++ b/munin-plugins-monroe/etc/munin/plugins/experiments
@@ -6,6 +6,6 @@ if [ "$1" == "config" ]; then
   echo "graph_title Running experiments";
   echo "running.label running experiments";
 else
-  GUIDS=$(join , $(sudo docker ps --format {{.Image}} | grep 'monroe-'));
+  GUIDS=$(join , $(/usr/bin/experiments));
   echo "running.value $GUIDS";
 fi


### PR DESCRIPTION
This removes duplication of code between the plugin and shell script. 

ps. maybe the package dependencies need to be updated so that we this cannot be installed without /usr/bin/experiments exists