### PR TITLE
Add check if script is already running

### DIFF
--- a/monroe-experiments/usr/bin/monroe-rsync-results
+++ b/monroe-experiments/usr/bin/monroe-rsync-results
@@ -5,6 +5,11 @@ export PATH=/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/b
 
 . /etc/default/monroe-experiments
 
+# do not run rsync if already running
+me=$(basename "$0");
+running=$(ps h -C "$me" | grep -wv $$ | wc -l);
+[[ $running > 1 ]] && exit;
+
 # do not run rsync if a user experiment is running
 experiments && exit 1 
 


### PR DESCRIPTION
If the rsync server is not responding, there may be multiple rsync processes on nodes trying to connect and/or transfer the same data. This edit adds a check if the script is already running. Source https://unix.stackexchange.com/questions/48505/how-to-make-sure-only-one-instance-of-a-bash-script-runs