### PR TITLE
Only send wifi metadata when connected

### DIFF
--- a/wifimetadata-publisher/usr/bin/wifimetadata-publisher
+++ b/wifimetadata-publisher/usr/bin/wifimetadata-publisher
@@ -104,7 +104,7 @@ def zmq_loop():
     seqnr = 0
     while True:
         wldata = parse_iwconfig()
-        if wldata:
+        if wldata and wldata.get("ESSID", 'off/any') != 'off/any' :
             wldata.update({"Timestamp": time.time(), "SequenceNumber": seqnr, "DataId": dataid, "DataVersion": datanr})
             seqnr += 1
             wldata.update(parse_pnw())


### PR DESCRIPTION
Not bulletproof (I guess it is possible to name your AP to 'off/any', not tested) but this is the quickest and smallest change to accomplish the  wanted behavior of not logging uninteresting data.

This has been tested on node 232 :
* Not associated : no output 
* Assosicated (no ip) : 
```
MONROE.META.DEVICE.WLAN.SIGNAL {"DataId": "MONROE.META.DEVICE.WLAN.SIGNAL", "Noise": -256, "InterfaceName": "wlan0:", "SequenceNumber": 5, "DataVersion": 1, "RSSI": -25, "Timestamp": 1561455122.138285, "Quality": 70, "ESSID": "fipy-wlan-e968"}
```
* Associcated (with ip): 
```
MONROE.META.DEVICE.WLAN.SIGNAL {"DataId": "MONROE.META.DEVICE.WLAN.SIGNAL", "Noise": -256, "InterfaceName": "wlan0:", "SequenceNumber": 12, "DataVersion": 1, "RSSI": -30, "Timestamp": 1561455157.420112, "IPAddress": "192.168.4.2", "Quality": 70, "ESSID": "fipy-wlan-e968"}
```